### PR TITLE
Modifying config.php.tmpl so that we can pull DB values for php applications

### DIFF
--- a/files/config.php.tmpl
+++ b/files/config.php.tmpl
@@ -2,4 +2,10 @@
 {{range gets "/config/*"}}
   ${{base .Key}} = "{{.Value}}";
 {{end}}
+{{/* We have 2 end statements below for the if and the range */}}
+{{ if exists "/config/Database/Server" }}
+  {{range gets "/config/Database/*"}}
+  ${{base .Key}} = "{{.Value}}";
+  {{end}}
+{{end}}
 ?>


### PR DESCRIPTION
Hi! 

I figured it would be easier if there was one config file for PHP applications and if they had DBs attached to them, we should be pulling those values from consul by default. So here's a pull request for the same.

Thanks! 